### PR TITLE
Ajout de la fonction `getPositionPriorityByType` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 const voies = require('./lib/voies')
-const {extractNumeroSuffixe, rewriteSuffixes} = require('./lib/numeros')
+const {extractNumeroSuffixe, rewriteSuffixes, getPositionPriorityByType} = require('./lib/numeros')
 const bal = require('./lib/bal')
 
 module.exports = {
   ...voies,
   ...bal,
   rewriteSuffixes,
-  extractNumeroSuffixe
+  extractNumeroSuffixe,
+  getPositionPriorityByType
 }

--- a/lib/numeros/index.js
+++ b/lib/numeros/index.js
@@ -1,5 +1,24 @@
 const {chain} = require('lodash')
 
+const POSITION_TYPES_PRIORITY = {
+  entrée: 10,
+  bâtiment: 8,
+  'cage d’escalier': 7,
+  logement: 6,
+  'service technique': 5,
+  'délivrance postale': 3,
+  parcelle: 2,
+  segment: 1
+}
+
+function getPositionPriorityByType(type) {
+  if (!type) {
+    return 0
+  }
+
+  return POSITION_TYPES_PRIORITY[type] || 0
+}
+
 function extractNumeroSuffixe(numeroComplet) {
   const result = String(numeroComplet).match(/^(\d+)(.*)$/i)
   if (!result) {
@@ -39,4 +58,4 @@ function rewriteSuffixes(adresses) {
     .value()
 }
 
-module.exports = {extractNumeroSuffixe, rewriteSuffixes}
+module.exports = {extractNumeroSuffixe, rewriteSuffixes, getPositionPriorityByType}

--- a/lib/numeros/index.test.js
+++ b/lib/numeros/index.test.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const {rewriteSuffixes} = require('.')
+const {rewriteSuffixes, getPositionPriorityByType} = require('.')
 
 test('b,t => bis,ter', t => {
   const adresses = [
@@ -29,3 +29,10 @@ test('a,b => a,b', t => {
   ])
 })
 
+test('Test types priority', t => {
+  t.is(getPositionPriorityByType('entrée'), 10)
+  t.is(getPositionPriorityByType('cage d’escalier'), 7)
+  t.is(getPositionPriorityByType('segment'), 1)
+  t.is(getPositionPriorityByType(), 0)
+  t.is(getPositionPriorityByType('entree'), 0)
+})


### PR DESCRIPTION
Cette PR propose d’ajouter la fonction `getPositionPriorityByType` , permettant de sélectionner la meilleure position à afficher.

Cette fonction sera utilisée dans l’api-mes-adresses afin d’afficher la position de type 'entrée' en priorité.